### PR TITLE
Streamline requirements.txt and fix script's import problems

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ For detailed installation instructions and troubleshooting, see [docs/install.md
 You can find the pretrained model from [Hugging Face](https://huggingface.co/projectaria/4DGT/) and download manually via:
 ```bash
 # By default, the downloaded model will be saved to checkpoints/4dgt_full.pth
-python tlod/download_model.py
+python -m tlod.download_model
 ```
 
 You can also skip this step and it will automatically download it when executing the following commands.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,14 @@
 --extra-index-url https://download.pytorch.org/whl/cu124
 torch>=2.1.0
-ninja
+# ninja
 transformers
 huggingface-hub
 torchvision
 torchaudio
-sunds>=0.4.1
-tensorflow>=2.6
+# sunds>=0.4.1
+# tensorflow>=2.6
 einops>=0.4.1
-wandb
+# wandb
 pyyaml
 imageio
 matplotlib
@@ -19,8 +19,8 @@ torchmetrics
 fvcore
 iopath
 lpips
-packaging
-ninja
+# packaging
+# ninja
 rich
 numpy<2.0
 plyfile
@@ -30,25 +30,27 @@ imageio[ffmpeg]
 scikit-image
 projectaria-tools[all]
 splines
-lightning
-lightning[pytorch-extra]
-natsort
+# lightning
+# lightning[pytorch-extra]
+# natsort
 plyfile
 PyMCubes
 rembg
-accelerate
-kornia
-viser>=0.2.3
-gsplat>=1.2.0
-nerfview
+# accelerate
+# kornia
+# viser>=0.2.3
+# gsplat>=1.2.0
+viser
+gsplat
+# nerfview
 open3d
-openexr-python
-diffusers
+# openexr-python
+# diffusers
 
-gpustat # for monitoring gpu usage easily
-colossalai # for traing LVSM
-openai-clip
-openai
+# gpustat # for monitoring gpu usage easily
+# colossalai # for traing LVSM
+# openai-clip
+# openai
 
 # For configs
 mmengine

--- a/tlod/registry.py
+++ b/tlod/registry.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 import torch.nn as nn
 
-from .easyvolcap.engine.registry import Registry
+from tlod.easyvolcap.engine.registry import Registry
 
 
 def build_module(module, builder, **kwargs):


### PR DESCRIPTION
Remove unused requirements in the `requirements.txt` file to fix timeout errors for installations.
Also fixed a script (`python -m tlod.download_model`) in the README to use module loading to avoid import problems for local packages.